### PR TITLE
fix typo in summary output

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -255,7 +255,7 @@ function install_deps {
       curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
       $SUDO mv ./kubectl /usr/local/bin/kubectl
       $SUDO chmod +x /usr/local/bin/kubectl
-      log  "Please review any setup requirements for 'kubsctl' from: https://kubernetes.io/docs/tasks/tools/install-kubectl/"
+      log  "Please review any setup requirements for 'kubectl' from: https://kubernetes.io/docs/tasks/tools/install-kubectl/"
     fi
 
     #-- helm:


### PR DESCRIPTION
The 'kubsctl' should be 'kubectl'.

Closes: #45