### PR TITLE
Windows security fix

### DIFF
--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -151,6 +151,7 @@ function install_deps() {
   if( -not (get-command git -erroraction 'silentlycontinue') -or $Global:FORCE) {
     log "Installing/updating external dependency: git"
     $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content
+    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
     Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v$gitVersion.windows.1/Git-$gitVersion-64-bit.exe" -UseBasicParsing -outfile "git-installer.exe"
     .\git-installer.exe /SILENT /PathOption="Cmd" | Out-Null
     Remove-Item "git-installer.exe"

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -149,10 +149,7 @@ function install_deps() {
   #-- git
   log "Checking for external dependency: git"
   if( -not (get-command git -erroraction 'silentlycontinue') -or $Global:FORCE) {
-    [Net.ServicePointManager]::SecurityProtocol = 
-      [Net.SecurityProtocolType]::Tls12 -bor `
-      [Net.SecurityProtocolType]::Tls11 -bor `
-      [Net.SecurityProtocolType]::Tls
+    [Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls11, Tls, Ssl3"
 
     log "Installing/updating external dependency: git"
     $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -146,11 +146,12 @@ function install() {
 #-- Install dependencies - git, docker, kubectl, helm.
 function install_deps() {
 
+  [Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls11, Tls, Ssl3"
+
   #-- git
   log "Checking for external dependency: git"
   if( -not (get-command git -erroraction 'silentlycontinue') -or $Global:FORCE) {
-    [Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls11, Tls, Ssl3"
-
+    
     log "Installing/updating external dependency: git"
     $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content
     Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v$gitVersion.windows.1/Git-$gitVersion-64-bit.exe" -UseBasicParsing -outfile "git-installer.exe"

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -151,7 +151,10 @@ function install_deps() {
   if( -not (get-command git -erroraction 'silentlycontinue') -or $Global:FORCE) {
     log "Installing/updating external dependency: git"
     $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content
-    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+    [Net.ServicePointManager]::SecurityProtocol = 
+      [Net.SecurityProtocolType]::Tls12 -bor `
+      [Net.SecurityProtocolType]::Tls11 -bor `
+      [Net.SecurityProtocolType]::Tls
     Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v$gitVersion.windows.1/Git-$gitVersion-64-bit.exe" -UseBasicParsing -outfile "git-installer.exe"
     .\git-installer.exe /SILENT /PathOption="Cmd" | Out-Null
     Remove-Item "git-installer.exe"

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -149,12 +149,13 @@ function install_deps() {
   #-- git
   log "Checking for external dependency: git"
   if( -not (get-command git -erroraction 'silentlycontinue') -or $Global:FORCE) {
-    log "Installing/updating external dependency: git"
-    $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content
     [Net.ServicePointManager]::SecurityProtocol = 
       [Net.SecurityProtocolType]::Tls12 -bor `
       [Net.SecurityProtocolType]::Tls11 -bor `
       [Net.SecurityProtocolType]::Tls
+
+    log "Installing/updating external dependency: git"
+    $gitVersion = (Invoke-WebRequest "https://git-scm.com/downloads/latest" -UseBasicParsing).Content
     Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v$gitVersion.windows.1/Git-$gitVersion-64-bit.exe" -UseBasicParsing -outfile "git-installer.exe"
     .\git-installer.exe /SILENT /PathOption="Cmd" | Out-Null
     Remove-Item "git-installer.exe"


### PR DESCRIPTION
updated `SecurityProtocol` to accept both TLS and SSL certificates beyond the defaults.