### PR TITLE
don't add a ppa for git

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -217,10 +217,6 @@ function install_deps {
     if [[ -z "$(which apt-get)" ]]; then
       error "'apt-get' is not found.  Thats the only linux installer I know, sorry."
     fi
-    if [[ -z "$(which add-apt-repository)" ]]; then
-      $SUDO apt-get install -y software-properties-common python-software-properties
-    fi
-    $SUDO add-apt-repository -y ppa:git-core/ppa
     $SUDO apt-get -y update
 
     #-- CURL:


### PR DESCRIPTION
Git has been part of base Ubuntu since at least 16.04 if not well
before that. There is no reason to add a ppa to get git on the system,
and ppa repositories can impact upgrade.