### PR TITLE
You don't need to add PPA for git

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -234,11 +234,6 @@ function install_deps_with_apt_get {
     if [[ -z "$(which apt-get)" ]]; then
       error "'apt-get' is not found.  That's the only Debian/Ubuntu linux installer I know, sorry."
     fi
-    if [[ -z "$(which add-apt-repository)" ]]; then
-      $SUDO apt-get install -y software-properties-common python-software-properties
-    fi
-    $SUDO add-apt-repository -y ppa:git-core/ppa
-    $SUDO apt-get -y update
 
     #-- CURL:
     log "Installing/updating external dependency: curl"


### PR DESCRIPTION
Debian oldstable and oldest Ubuntu LTS contains git package, so I don't see any reason to add PPA for git.

And, well, last line was automatically modified at commit.
