### PR TITLE
idt-installer: Add support to Linux@IBM Clients moving Red Hat as priority distro.

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -483,7 +483,7 @@ function main {
     ;;
   "Linux")
     # Linux distro, e.g "Ubuntu", "RedHatEnterpriseWorkstation", "RedHatEnterpriseServer", "CentOS", "Debian"
-    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
+    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/redhat-release 2>/dev/null | head -n1 || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
     if [[ "$DISTRO" != *Ubuntu* &&  "$DISTRO" != *RedHat* && "$DISTRO" != *CentOS* && "$DISTRO" != *Debian* ]]; then
       warn "Linux has only been tested on Ubuntu, RedHat, Centos & Debian distrubutions please let us know if you use this utility on other Distros"
     fi


### PR DESCRIPTION
Linux@IBM Clients are the oficial Linux Clients supported by IBM. It has
a file called openclient-release inside /etc which is conflicting with
redhat-release. So, when user run idt-installer, the script shows that
the OS is not supported. But it is because Linux@IBM Clients are Red Hat
based.

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>