### PR TITLE
Revert "idt-installer: Add support to Linux@IBM Clients moving Red Hat as priority distro."

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -483,7 +483,7 @@ function main {
     ;;
   "Linux")
     # Linux distro, e.g "Ubuntu", "RedHatEnterpriseWorkstation", "RedHatEnterpriseServer", "CentOS", "Debian"
-    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/redhat-release 2>/dev/null | head -n1 || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
+    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
     if [[ "$DISTRO" != *Ubuntu* &&  "$DISTRO" != *RedHat* && "$DISTRO" != *CentOS* && "$DISTRO" != *Debian* ]]; then
       warn "Linux has only been tested on Ubuntu, RedHat, Centos & Debian distrubutions please let us know if you use this utility on other Distros"
     fi


### PR DESCRIPTION
This change is breaking other Linux distributions per #102 . Reverting so that we can move to a fix that does not break other environments. 

Reverts IBM-Cloud/ibm-cloud-developer-tools#101
