### PR TITLE
When user specifies force flag, core cli should be forced update as well.

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -351,7 +351,11 @@ function install_bx {
     log "IBM Cloud 'bx' CLI install finished."
   else #-- Upgrade
     log "Updating existing IBM Cloud 'bx' CLI..."
-    bx update
+    if [[ "$FORCE" == true ]]; then
+      bx update -f
+    else
+      bx update
+    fi
   fi
   log "Running 'bx --version'..."
   bx --version

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -239,7 +239,14 @@ function add_to_path {
 function install_bx() {
   if( get-command bx -erroraction 'silentlycontinue') {
       Write-Output "ibmcloud already installed"
-      bx update
+      if( $Global:FORCE ){
+        # User wants forced update
+        bx update -f
+      } else {
+        # User will be prompted if they want to update
+        bx update
+      }
+      
   } else {
     log "Installing 'ibmcloud' CLI for Windows..."
     $url = $Global:IDT_INSTALL_BMX_URL + "/powershell"


### PR DESCRIPTION
when a user does something like `linux-installer/idt-installer --force`, core IBM CLI should be forced updated as well.