### PR TITLE
Fix curl options for downloading kubectl

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -164,7 +164,7 @@ function install_darwin_deps {
     log "Installing/updating external dependency: kubectl"
     if [[ -z "$(which kubectl)" || "$FORCE" == true ]]; then
       local kube_version=$(get_kubectl_version)
-      curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/v$kube_version/bin/darwin/amd64/kubectl
+      curl -fsSLo kubectl https://storage.googleapis.com/kubernetes-release/release/v$kube_version/bin/darwin/amd64/kubectl
       $SUDO mv ./kubectl /usr/local/bin/kubectl
       $SUDO chmod +x /usr/local/bin/kubectl
       log  "Please review any setup requirements for 'kubectl' from: https://kubernetes.io/docs/tasks/tools/install-kubectl/"
@@ -212,7 +212,7 @@ function install_deps_with_apt_get {
     log "Installing/updating external dependency: kubectl"
     if [[ -z "$(which kubectl)" || "$FORCE" == true ]]; then
       local kube_version=$(get_kubectl_version)
-      curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/v$kube_version/bin/linux/amd64/kubectl
+      curl -fsSLo kubectl https://storage.googleapis.com/kubernetes-release/release/v$kube_version/bin/linux/amd64/kubectl
       $SUDO mv ./kubectl /usr/local/bin/kubectl
       $SUDO chmod +x /usr/local/bin/kubectl
       log  "Please review any setup requirements for 'kubectl' from: https://kubernetes.io/docs/tasks/tools/install-kubectl/"


### PR DESCRIPTION
At the moment, the command for downloading kubectl binary has a hidden but real issue.
"--progress-bar -LO" options make it look good but curl won't fail if, by any chances, it is not able to download a binary. It's even worse, curl does create a file which contains an error message and is named 'kubectl'.

```
$ curl --progress-bar -LO https://storage.googleapis.com/kubernetes-release/release/v000000/bin/darwin/amd64/kubectl
####################################################################################################################################################################### 100.0%

$ cat kubectl 
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v000000/bin/darwin/amd64/kubectl</Details></Error>
```

On the next step, the script moves this "binary" to /usr/loca/bin/, assigns an executable flag and an end user eventually will run this xml file instead of real kubectl tool.
What it really has to do is to fail (return non 0 exit code) and do not create any file at all.

Of course, there is another, global problem, but it's not bound to the scope of this issue. 
A bigger problem is that, it doesn't matter curl creates a file with a wrong content or it doesn't, the script it self won't react on a non-zero exit code of any commands and nothing stops it from going further. So, if the script is not able to download a working copy of binary, it won't tell anyone about that. It will be a surprise for user later ;) 

Anyway, I think, it's another issue and it's a subject to discussion in another thread.
