### PR TITLE
Force update plugins

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -329,7 +329,7 @@ function install_plugins {
     read -r p ver <<< "$(bx plugin list | grep "^${plugin} ")"
     if [[ -z "$p" ]]; then
       log "Installing plugin '$plugin'"
-      bx plugin install -r "${IDT_INSTALL_BMX_REPO_NAME}" "$plugin"
+      bx plugin install -f -r "${IDT_INSTALL_BMX_REPO_NAME}" "$plugin"
     else
       log "Updating plugin '$plugin' from version '$ver'"
       bx plugin update -r "${IDT_INSTALL_BMX_REPO_NAME}" "$plugin"

--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -267,7 +267,7 @@ function install_plugins {
         iex "$bx_command plugin update -r $Global:IDT_INSTALL_BMX_REPO_NAME $plugin"
     } else {
         log "Installing plugin '$plugin'"
-        iex "$bx_command plugin install -r $Global:IDT_INSTALL_BMX_REPO_NAME $plugin"
+        iex "$bx_command plugin install -f -r $Global:IDT_INSTALL_BMX_REPO_NAME $plugin"
     }
   }
   log "Running 'ibmcloud plugin list'..."


### PR DESCRIPTION
users have been experiencing issues when they run the script and a plugin already exists but is out of date. This will force update the plugin if there is already that plugin installed.

https://github.com/IBM-Cloud/ibm-cloud-developer-tools/issues/120