### PR TITLE
Fix linux ubuntu install

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -190,6 +190,9 @@ function install_deps_with_apt_get {
     if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y software-properties-common python-software-properties
     fi
+    if [[ -z "$(which add-apt-repository)" ]]; then
+      $SUDO apt-get install -y python-software-properties
+    fi
     $SUDO add-apt-repository -y ppa:git-core/ppa
     $SUDO apt-get -y update
 

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -189,9 +189,8 @@ function install_deps_with_apt_get {
     $SUDO apt-get -y update
     if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y software-properties-common
-    fi
-    if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y python-software-properties
+      $SUDO apt-get install -y python3-software-properties
     fi
     $SUDO add-apt-repository -y ppa:git-core/ppa
     $SUDO apt-get -y update

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -186,11 +186,11 @@ function install_deps_with_apt_get {
     if [[ -z "$(which apt-get)" ]]; then
       error "'apt-get' is not found.  That's the only Debian/Ubuntu linux installer I know, sorry."
     fi
-    $SUDO apt-get -y update
+    $SUDO apt-get -y -qq update > /dev/null
     if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y software-properties-common
-      $SUDO apt-get install -y python-software-properties
-      $SUDO apt-get install -y python3-software-properties
+      $SUDO apt-get install -y python-software-properties || true
+      $SUDO apt-get install -y python3-software-properties || true
     fi
     $SUDO add-apt-repository -y ppa:git-core/ppa
     $SUDO apt-get -y update

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -188,9 +188,14 @@ function install_deps_with_apt_get {
     fi
     $SUDO apt-get -y -qq update > /dev/null
     if [[ -z "$(which add-apt-repository)" ]]; then
-      $SUDO apt-get install -y software-properties-common
-      $SUDO apt-get install -y python-software-properties || true
-      $SUDO apt-get install -y python3-software-properties || true
+      if [ "$(apt-cache search software-properties-common | wc -l)" != "0" ]; then
+        log "Installing package: software-properties-common"
+        $SUDO apt-get install -yqq software-properties-common > /dev/null 2>&1
+      fi
+      if [ "$(apt-cache search python-software-properties | wc -l)" != "0" ]; then
+        log "Installing package: python-software-properties"
+        $SUDO apt-get install -yqq python-software-properties > /dev/null 2>&1
+      fi
     fi
     $SUDO add-apt-repository -y ppa:git-core/ppa
     $SUDO apt-get -y update

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -186,6 +186,7 @@ function install_deps_with_apt_get {
     if [[ -z "$(which apt-get)" ]]; then
       error "'apt-get' is not found.  That's the only Debian/Ubuntu linux installer I know, sorry."
     fi
+    $SUDO apt-get -y update
     if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y software-properties-common python-software-properties
     fi

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -188,7 +188,7 @@ function install_deps_with_apt_get {
     fi
     $SUDO apt-get -y update
     if [[ -z "$(which add-apt-repository)" ]]; then
-      $SUDO apt-get install -y software-properties-common python-software-properties
+      $SUDO apt-get install -y software-properties-common
     fi
     if [[ -z "$(which add-apt-repository)" ]]; then
       $SUDO apt-get install -y python-software-properties


### PR DESCRIPTION
This PR fixes 2 bugs in the linux installer version:

1) It does an initial `apt-get update` before trying to install the `software-properties-common` package because systems which never had an `apt-get update` done (like some docker images) might not find the package in the first place.

2) Trying to install both packages `software-properties-common` and `python-software-properties` at the same time resulted in the error `E: Package 'python-software-properties' has no installation candidate` for me (Ubuntu 18.04.). Since one package replaces the other the command fails without installing the other package and nothing gets installed. Doing it in separate commands mitigates this issue.