### PR TITLE
Updated idt-installer, #127

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -117,7 +117,7 @@ function install_deps {
       install_darwin_deps
     ;;
   "Linux")
-    if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
+    if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* || "${DISTRO}" == *Pop!_OS* ]]; then
       install_deps_with_apt_get
     elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
       install_deps_with_yum


### PR DESCRIPTION
Made Pop!_OS compatible with the apt-get installation.
Referring to issue #127.