### PR TITLE
Adding openSUSE Tumbleweed support for instalation

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -119,7 +119,7 @@ function install_deps {
   "Linux")
     if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
       install_deps_with_apt_get
-    elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
+    elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* || "${DISTRO}" == *openSUSE*Tumbleweed*]]; then
       install_deps_with_yum
     else
       error "This script has not been updated for use with your linux distribution (${DISTRO})"

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -119,7 +119,7 @@ function install_deps {
   "Linux")
     if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
       install_deps_with_apt_get
-    elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* || "${DISTRO}" == *openSUSE*Tumbleweed*]]; then
+    elif [[ "${DISTRO}" == *openSUSE*Tumbleweed* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
       install_deps_with_yum
     else
       error "This script has not been updated for use with your linux distribution (${DISTRO})"
@@ -388,7 +388,7 @@ function main {
   (( SECS = SECONDS ))
 
   TMPDIR=${TMPDIR:-"/tmp"}
-  PLATFORM=$(uname)
+  PLATFORM="fedora"
   ACTION=""
 
   # Only use sudo if not running as root:

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -119,7 +119,7 @@ function install_deps {
   "Linux")
     if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
       install_deps_with_apt_get
-    elif [[ "${DISTRO}" == *openSUSE*Tumbleweed* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
+    elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
       install_deps_with_yum
     else
       error "This script has not been updated for use with your linux distribution (${DISTRO})"
@@ -388,7 +388,7 @@ function main {
   (( SECS = SECONDS ))
 
   TMPDIR=${TMPDIR:-"/tmp"}
-  PLATFORM="fedora"
+  PLATFORM=Fedora
   ACTION=""
 
   # Only use sudo if not running as root:

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -418,6 +418,9 @@ function main {
   "Linux")
     # Linux distro, e.g "Ubuntu", "RedHatEnterpriseWorkstation", "RedHatEnterpriseServer", "CentOS", "Debian"
     DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
+    if[["$DISTRO"==*openSUSE*Tumbleweed*]]; then
+      DISTRO=*Fedora* #because openSuse Tumbleweed has the same instalation process as fedora has.
+    fi
     if [[ "$DISTRO" != *Ubuntu* &&  "$DISTRO" != *Red*Hat* && "$DISTRO" != *CentOS* && "$DISTRO" != *Debian* && "$DISTRO" != *RHEL* && "$DISTRO" != *Fedora* ]]; then
       warn "Linux has only been tested on Ubuntu, RedHat, Centos, Debian and Fedora distrubutions please let us know if you use this utility on other Distros"
     fi

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -388,7 +388,7 @@ function main {
   (( SECS = SECONDS ))
 
   TMPDIR=${TMPDIR:-"/tmp"}
-  PLATFORM=Fedora
+  PLATFORM=$(uname)
   ACTION=""
 
   # Only use sudo if not running as root:
@@ -417,7 +417,7 @@ function main {
     ;;
   "Linux")
     # Linux distro, e.g "Ubuntu", "RedHatEnterpriseWorkstation", "RedHatEnterpriseServer", "CentOS", "Debian"
-    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
+    DISTRO=*Fedora*
     if [[ "$DISTRO" != *Ubuntu* &&  "$DISTRO" != *Red*Hat* && "$DISTRO" != *CentOS* && "$DISTRO" != *Debian* && "$DISTRO" != *RHEL* && "$DISTRO" != *Fedora* ]]; then
       warn "Linux has only been tested on Ubuntu, RedHat, Centos, Debian and Fedora distrubutions please let us know if you use this utility on other Distros"
     fi

--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -417,7 +417,7 @@ function main {
     ;;
   "Linux")
     # Linux distro, e.g "Ubuntu", "RedHatEnterpriseWorkstation", "RedHatEnterpriseServer", "CentOS", "Debian"
-    DISTRO=*Fedora*
+    DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om || echo "")
     if [[ "$DISTRO" != *Ubuntu* &&  "$DISTRO" != *Red*Hat* && "$DISTRO" != *CentOS* && "$DISTRO" != *Debian* && "$DISTRO" != *RHEL* && "$DISTRO" != *Fedora* ]]; then
       warn "Linux has only been tested on Ubuntu, RedHat, Centos, Debian and Fedora distrubutions please let us know if you use this utility on other Distros"
     fi


### PR DESCRIPTION
Since openSUSE Tumbleweed has almost the same fedora instalation process, I did an if when the distro is opensuse so they define distro as Fedora in order to execute the truth instalation.

This worked in my machinne very well!

PS.: to execute the user must install the yum package, as bellow:
sudo zypper install yum