### PR TITLE
Homebrew formula name change for helm

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -173,10 +173,10 @@ function install_darwin_deps {
     #-- helm:
     log "Installing/updating external dependency: helm"
     if [[ -z "$(which helm)" ]]; then
-      brew install kubernetes-helm
+      brew install helm
       log  "Please review any setup requirements for 'helm' from: https://github.com/kubernetes/helm/blob/master/docs/install.md"
     elif [[ "$FORCE" == true ]]; then
-      brew upgrade kubernetes-helm
+      brew upgrade helm
     fi
 }
 


### PR DESCRIPTION
Keeping up to date with the new formula name on homebrew:

`kubernetes-helm` ~> `helm`

As per this commit to hombrew-core: https://github.com/Homebrew/homebrew-core/commit/916eb2d1b6911789c04504a7427a7e079794d309