### PR TITLE
Update idt-installer to suport Linux Mint

### DIFF
--- a/linux-installer/idt-installer
+++ b/linux-installer/idt-installer
@@ -117,7 +117,7 @@ function install_deps {
       install_darwin_deps
     ;;
   "Linux")
-    if [[ "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
+    if [[ "${DISTRO}" == *Mint* || "${DISTRO}" == *Ubuntu* || "${DISTRO}" == *Debian* ]]; then
       install_deps_with_apt_get
     elif [[ "${DISTRO}" == *Red*Hat* || "${DISTRO}" == *CentOS* || "${DISTRO}" == *RHEL* || "${DISTRO}" == *Fedora* ]]; then
       install_deps_with_yum


### PR DESCRIPTION
Linux Mint is added as supported distribution to install on. Linux Mint is based on Ubuntu.